### PR TITLE
Add missing build dep and tweak setup.py

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -6,6 +6,7 @@ Build-Depends:
  debhelper (>= 10),
  dh-python,
  python3-all (>= 3.7~),
+ python3-pycurl,
 Standards-Version: 4.0.0
 
 Package: py3curl-wrapper

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,9 @@ def get_version():
     version = [ line.split(" ")[1]
                 for line in output.split("\n")
                 if line.startswith("Version:") ][0]
+    # dirty hack to make sure version is py setuptools compliant
+    if '+g' in version and len(version.split('+')) == 3:
+        version = version.replace('+g', '.devg')
     return version
 
 def parse_control(control):
@@ -66,5 +69,3 @@ def main():
 
 if __name__=="__main__":
     main()
-
-


### PR DESCRIPTION
I was having problems building this for Bookworm these commits helped.

The version tweak is pretty dirty and I'm not proud of it. OTOH it's in the `setup.py` from a package we maintain and the test I use is consistent with output from `autoversion` (which is where this version string is coming from).